### PR TITLE
Add support for filtering headers and query params.

### DIFF
--- a/Sources/DVR/Filter.swift
+++ b/Sources/DVR/Filter.swift
@@ -26,18 +26,29 @@
 
 import Foundation
 
+/// Filters to redact senstive information or otherwise manipulate the request/response.
 public struct Filter {
-    public var replacements : [String : String]
-    public var beforeRecordResponse : ((Foundation.URLResponse, Data?) -> (Foundation.URLResponse, Data?))
-    public var beforeRecordRequest : ((URLRequest) -> (URLRequest))
+
+    /// Describes the desired filter behavior
+    public enum FilterBehavior {
+        /// Value is completed ommitted
+        case remove
+        /// Value is replaced with a static string
+        case replace(String)
+        /// Value is determined by a closure which accepts the key and value and can return a new value or nil to omit
+        case closure((String, String?) -> (String?))
+    }
+
+    /// filters to apply to headers
+    public var filterHeaders: [String: FilterBehavior]?
+    /// filters to apply to query parameters
+    public var filterQueryParameters: [String: FilterBehavior]?
+    /// filters to apply to post data parameters
+    public var filterPostDataParameters: [String: FilterBehavior]?
+    /// a closure to call when processing each response
+    public var beforeRecordResponse: ((Foundation.URLResponse, Data?) -> (Foundation.URLResponse, Data?)?)?
+    /// a closure to call when processing each request
+    public var beforeRecordRequest: ((URLRequest) -> (URLRequest))?
     
-    public init(replacements: [String:String] = [:], queryParameters: [String:String] = [:], postDataParameters: [String:String] = [:], requestHook : @escaping ((URLRequest) -> (URLRequest)) = {return $0} , responseHook : @escaping ((Foundation.URLResponse, Data?) -> (Foundation.URLResponse, Data?)) = {return ($0, $1) } ) {
-        self.replacements = replacements
-        self.beforeRecordRequest = requestHook
-        self.beforeRecordResponse = responseHook
-    }
-   
-    public mutating func addReplacement(key: String, value: String = "Redacted") {
-        self.replacements.updateValue(key, forKey: value)
-    }
+    public init() {}
 }

--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -26,7 +26,6 @@ final class SessionDataTask: URLSessionDataTask {
         return request
     }
 
-
     // MARK: - Initializers
 
     init(session: Session, request: URLRequest, headersToCheck: [String] = [], completion: (Completion)? = nil) {
@@ -36,7 +35,6 @@ final class SessionDataTask: URLSessionDataTask {
         self.completion = completion
     }
 
-
     // MARK: - URLSessionTask
 
     override func cancel() {
@@ -44,13 +42,15 @@ final class SessionDataTask: URLSessionDataTask {
     }
 
     override func resume() {
-        
-        
+
+        // apply request transformations, which could impact matching the interaction
+        let filteredRequest = filter(request: request)
+
         if session.recordMode != .all {
             let cassette = session.cassette
 
             // Find interaction
-            if let interaction = session.cassette?.interactionForRequest(request, headersToCheck: headersToCheck) {
+            if let interaction = session.cassette?.interactionForRequest(filteredRequest, headersToCheck: headersToCheck) {
                 self.interaction = interaction
                 // Forward completion
                 if let completion = completion {
@@ -78,9 +78,7 @@ final class SessionDataTask: URLSessionDataTask {
                 fatalError("[DVR] Recording is disabled.")
             }
         }
-        
-        
-        
+
         let task = session.backingSession.dataTask(with: request, completionHandler: { [weak self] data, response, error in
 
             //Ensure we have a response
@@ -97,13 +95,96 @@ final class SessionDataTask: URLSessionDataTask {
                 this.completion?(data, response, nil)
             }
             
-            // Create interaction
-            let filteredRequest = this.session.filter.beforeRecordRequest(this.request)
-            let filteredResponseTuple = this.session.filter.beforeRecordResponse(response,data)
-            this.interaction = Interaction(request: filteredRequest, response: filteredResponseTuple.0, responseData: filteredResponseTuple.1)
-            this.session.finishTask(this, interaction: this.interaction!, playback: false)
+            // Create interaction unless the response has been filtered out
+            if let (filteredResponse, filteredData) = this.filter(response: response, withData: data) {
+                // persist the interaction
+                this.interaction = Interaction(request: filteredRequest, response: filteredResponse, responseData: filteredData)
+                this.session.finishTask(this, interaction: this.interaction!, playback: false)
+            } else {
+                // do not persist the interaction if the filtered response was nil
+                this.interaction = Interaction(request: filteredRequest, response: response, responseData: data)
+                this.session.finishTask(this, interaction: this.interaction!, playback: true)
+            }
         })
         task.resume()
+    }
+
+    // MARK: - Internal Methods
+
+    func filterHeaders(for request: inout URLRequest) {
+        // return early if request has no headers
+        guard var filteredHeaders = request.allHTTPHeaderFields else {
+            return
+        }
+        for (key, filter) in session.filter.filterHeaders ?? [:] {
+            guard let match = filteredHeaders[key] else {
+                continue
+            }
+            switch filter {
+            case .remove:
+                filteredHeaders[key] = nil
+            case let .replace(replacement):
+                filteredHeaders[key] = replacement
+            case let .closure(function):
+                filteredHeaders[key] = function(key, match)
+            }
+        }
+        request.allHTTPHeaderFields = filteredHeaders
+    }
+
+    func filterQueryParams(for request: inout URLRequest) {
+        // return early if request has no query params
+        guard let url = request.url,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            return
+        }
+        var filteredQueryParams: [URLQueryItem] = []
+        for item in queryItems {
+            guard let filterMatch = session.filter.filterQueryParameters?[item.name] else {
+                continue
+            }
+            switch filterMatch {
+            case .remove:
+                continue
+            case let .replace(replacement):
+                filteredQueryParams.append(URLQueryItem(name: item.name, value: replacement))
+            case let .closure(function):
+                // don't add if the closure returns nil
+                if let newValue = function(item.name, item.value) {
+                    filteredQueryParams.append(URLQueryItem(name: item.name, value: newValue))
+                }
+            }
+        }
+        components.queryItems = filteredQueryParams
+        request.url = components.url
+    }
+
+    func filterPostParams(for request: inout URLRequest) {
+        // return early if request is not a POST or has no body params
+        guard request.httpMethod == "POST",
+              let httpBody = request.httpBody,
+              var jsonBody = try? JSONSerialization.jsonObject(with: httpBody, options: [.mutableContainers]) else {
+            return
+        }
+        // TODO: needs to account for different ways of encoding form data
+    }
+
+    func filter(request: URLRequest) -> URLRequest {
+        var filtered = request
+        filterHeaders(for: &filtered)
+        filterQueryParams(for: &filtered)
+        filterPostParams(for: &filtered)
+        filtered = session.filter.beforeRecordRequest?(filtered) ?? filtered
+        return filtered
+    }
+
+    func filter(response: Foundation.URLResponse, withData data: Data?) -> (Foundation.URLResponse, Data?)? {
+        //  return the same data if no filter present
+        guard let responseFilter = session.filter.beforeRecordResponse else {
+            return (response, data)
+        }
+        return responseFilter(response, data)
     }
 }
 

--- a/Tests/DVRTests/FilterTests.swift
+++ b/Tests/DVRTests/FilterTests.swift
@@ -22,7 +22,7 @@ class FilterTests: XCTestCase {
         var response = Foundation.HTTPURLResponse(
             url: URL(string: "https://www.example/com")!,
             statusCode: 200,
-            httpVersion: "1.2",
+            httpVersion: "",
             headerFields: ["header1": "value1", "header2": "value2", "header3": "value3"]
         )
         return response!
@@ -79,7 +79,7 @@ class FilterTests: XCTestCase {
             let newResponse = Foundation.HTTPURLResponse(
                 url: httpResponse.url!,
                 statusCode: httpResponse.statusCode,
-                httpVersion: "1.2",
+                httpVersion: "",
                 headerFields: newHeaders
             )
             let newData: Data? = nil
@@ -89,8 +89,7 @@ class FilterTests: XCTestCase {
         let headers = (cleanedResponse as! Foundation.HTTPURLResponse).allHeaderFields
         XCTAssertNil(headers["header1"])
         XCTAssertEqual(headers["header2"] as! String, "redacted")
-        XCTAssertEqual(headers["header3"] as! String, "header3+stuff3")
+        XCTAssertEqual(headers["header3"] as! String, "header3+value3")
         XCTAssertEqual(headers["header4"] as! String, "value4")
-
     }
 }

--- a/Tests/DVRTests/FilterTests.swift
+++ b/Tests/DVRTests/FilterTests.swift
@@ -8,97 +8,89 @@
 
 import XCTest
 import Foundation
-import DVR
+@testable import DVR
 
 class FilterTests: XCTestCase {
 
-    let testurl = URL(string: "http://example.com")!
-    let testURL2 = URL(string: "https://httpbin.org/ip")
-    let testURL3 = URL(string: "https://api.publicapis.org/entries")
-    
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        
-    }
+    lazy var request: URLRequest = {
+        var request = URLRequest(url: URL(string: "https://www.example.com?param1=val1&param2=val2&param3=val3")!)
+        request.allHTTPHeaderFields = ["header1": "stuff1", "header2": "stuff2", "header3": "stuff3"]
+        return request
+    }()
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
+    lazy var response: Foundation.HTTPURLResponse = {
+        var response = Foundation.HTTPURLResponse(
+            url: URL(string: "https://www.example/com")!,
+            statusCode: 200,
+            httpVersion: "1.2",
+            headerFields: ["header1": "value1", "header2": "value2", "header3": "value3"]
+        )
+        return response!
+    }()
 
-    func cleanRequestWithFilter(filter: Filter) -> ((URLRequest)->(URLRequest)){
-        return { request in
-            var cleanRequest = request
-            let dirtyHeaders = request.allHTTPHeaderFields ?? [:]
-            var cleanHeaders = dirtyHeaders
-            
-            for key in filter.replacements.keys {
-                if dirtyHeaders[key] != nil {
-                    cleanHeaders[key] = filter.replacements[key]
-                }
+    // ensures that requests are scrubbed appropriately
+    func testRequestFilters() throws {
+        var filter = Filter()
+        filter.filterHeaders = [
+            "header1": .remove,
+            "header2": .replace("redacted"),
+            "header3": .closure { key, val in
+                return "\(key)+\(val!)"
             }
-            cleanRequest.allHTTPHeaderFields = cleanHeaders
-            
-            return cleanRequest
+        ]
+        filter.filterQueryParameters = [
+            "param1": .remove,
+            "param2": .replace("redacted"),
+            "param3": .closure { key, val in
+                return "\(key)\(val!)"
+            }
+        ]
+        filter.beforeRecordRequest = { request in
+            var newRequest = request
+            newRequest.addValue("value4", forHTTPHeaderField: "header4")
+            return newRequest
         }
-        
-        
+        let cleanedRequest = filter.filter(request: request)
+        let queryTuples = URLComponents(url: cleanedRequest.url!, resolvingAgainstBaseURL: true)!.queryItems!
+        let queryItems = queryTuples.reduce(into: [:]) { $0[$1.name] = $1.value }
+        XCTAssertNil(cleanedRequest.allHTTPHeaderFields!["header1"])
+        XCTAssertEqual(cleanedRequest.allHTTPHeaderFields!["header2"], "redacted")
+        XCTAssertEqual(cleanedRequest.allHTTPHeaderFields!["header3"], "header3+stuff3")
+        XCTAssertEqual(cleanedRequest.allHTTPHeaderFields!["header4"], "value4")
+        XCTAssertNil(queryItems["param1"])
+        XCTAssertEqual(queryItems["param2"], "redacted")
+        XCTAssertEqual(queryItems["param3"], "param3val3")
     }
-    
-    func cleanResponseWithFilter(filter: Filter) -> ((URLResponse,Data?)->(URLResponse,Data?)) {
-        return { response, data in
-            var jsonData = try! JSONSerialization.jsonObject(with: data!, options: []) as? [String : Any]
-            for key in filter.replacements.keys {
-                if jsonData![key] != nil {
-                    jsonData![key] = filter.replacements[key]
-                }
+
+    // ensures that responses are scrubbed appropriately
+    func testResponseFilters() throws {
+        var filter = Filter()
+        filter.filterHeaders = [
+            "header1": .remove,
+            "header2": .replace("redacted"),
+            "header3": .closure { key, val in
+                return "\(key)+\(val!)"
             }
-            print(JSONSerialization.isValidJSONObject(jsonData))
-            return try! (response, JSONSerialization.data(withJSONObject: jsonData, options: []))
+        ]
+        filter.beforeRecordResponse = { response, data in
+            let httpResponse = response as! Foundation.HTTPURLResponse
+            var newHeaders = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.map { ($0 as! String, $1 as! String) })
+            newHeaders["header4"] = "value4"
+            let newResponse = Foundation.HTTPURLResponse(
+                url: httpResponse.url!,
+                statusCode: httpResponse.statusCode,
+                httpVersion: "1.2",
+                headerFields: newHeaders
+            )
+            let newData: Data? = nil
+            return (newResponse!, newData)
         }
-    }
-    
-    //ensures that requests are scrubbed appropriately
-    func testRequestCleanse() throws {
-        var filter = Filter(replacements: ["Expires" : "Redacted", "Authorization" : "Redacted"])
-        filter.beforeRecordRequest = cleanRequestWithFilter(filter: filter)
-        
-        let session = Session(cassetteName: "test_cassette" , filter: filter)
-        
-        var request = URLRequest(url: testurl)
-        request.allHTTPHeaderFields = [:]
-        request.allHTTPHeaderFields!["Authorization"] = "1234-5678-9000"
-        print("Here")
-        print(request.allHTTPHeaderFields!)
-        let cleanedRequest = cleanRequestWithFilter(filter: filter)(request)
-        print(cleanedRequest.allHTTPHeaderFields!)
-        XCTAssert(cleanedRequest.allHTTPHeaderFields!["Authorization"]=="Redacted")
-        
-    }
-    
-    //ensures that responses are scrubbed appropriately
-    func testResponseCleanse() throws {
-        var filter = Filter(replacements: ["origin":"000.0.000.000"])
-        filter.beforeRecordResponse = cleanResponseWithFilter(filter: filter)
-        
-        let session = URLSession.shared
-        
-        let expect = expectation(description: "wait for print")
-        session.dataTask(with: testURL2!) { [self] data, urlResponse, error in
-            print("here")
-            if let httpResponse = urlResponse as? HTTPURLResponse {
-                print(httpResponse.statusCode)
-            }
-            let jsonData = try! JSONSerialization.jsonObject(with: data!, options: []) as? [String : Any]
-            print(jsonData)
-            var cleansedData = filter.beforeRecordResponse(urlResponse!, data).1
-            let cleanJson = try! JSONSerialization.jsonObject(with: cleansedData!, options: []) as? [String : Any]
-            XCTAssert(cleanJson!["origin"] as! String=="000.0.000.000")
-            expect.fulfill()
-        }.resume()
-        
-        waitForExpectations(timeout: 10, handler: nil)
-    }
+        let (cleanedResponse, _) = filter.filter(response: response, withData: nil)!
+        let headers = (cleanedResponse as! Foundation.HTTPURLResponse).allHeaderFields
+        XCTAssertNil(headers["header1"])
+        XCTAssertEqual(headers["header2"] as! String, "redacted")
+        XCTAssertEqual(headers["header3"] as! String, "header3+stuff3")
+        XCTAssertEqual(headers["header4"] as! String, "value4")
 
-    
-
+    }
 }


### PR DESCRIPTION
Partially addressed #4.

Follows VCR.py guidance [here](https://vcrpy.readthedocs.io/en/latest/advanced.html#advanced-use-of-filter-headers-filter-query-parameters-and-filter-post-data-parameters) which allows the user to specify the behavior of the filter.

POST param processing is a lot trickier since there are various ways of encoding form data, so I left that as a TODO. AzureTest only needs header processing really. 