### PR TITLE
Header filter case-insensitive matching

### DIFF
--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A6A5459268BB2F5001006AF /* Dict+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A5458268BB2F5001006AF /* Dict+Extension.swift */; };
 		2104F5451DC658A20039CA14 /* DVR.h in Headers */ = {isa = PBXBuildFile; fileRef = 3647AF9E1B335D5500EF10D4 /* DVR.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2104F5461DC658A60039CA14 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFB81B335E4A00EF10D4 /* Session.swift */; };
 		2104F5471DC658A60039CA14 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3647AFB91B335E4A00EF10D4 /* SessionDataTask.swift */; };
@@ -102,6 +103,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A6A5458268BB2F5001006AF /* Dict+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dict+Extension.swift"; sourceTree = "<group>"; };
 		2104F52E1DC658580039CA14 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2104F5361DC658590039CA14 /* DVRTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DVRTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3123728A26823CDE006C4D9E /* Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				360F5F721B5C907A001AADD1 /* SessionDownloadTask.swift */,
 				B19D62641CB1860400E16D11 /* SessionUploadTask.swift */,
 				3647AFB51B335E4A00EF10D4 /* Cassette.swift */,
+				0A6A5458268BB2F5001006AF /* Dict+Extension.swift */,
 				3647AFB61B335E4A00EF10D4 /* Interaction.swift */,
 				3123728A26823CDE006C4D9E /* Filter.swift */,
 				3647AFB71B335E4A00EF10D4 /* URLRequest.swift */,
@@ -591,6 +594,7 @@
 				3647AFBE1B335E4A00EF10D4 /* SessionDataTask.swift in Sources */,
 				3647AFBD1B335E4A00EF10D4 /* Session.swift in Sources */,
 				360F5F731B5C907A001AADD1 /* SessionDownloadTask.swift in Sources */,
+				0A6A5459268BB2F5001006AF /* Dict+Extension.swift in Sources */,
 				3647AFBC1B335E4A00EF10D4 /* URLRequest.swift in Sources */,
 				3647AFBB1B335E4A00EF10D4 /* Interaction.swift in Sources */,
 				3647AFBA1B335E4A00EF10D4 /* Cassette.swift in Sources */,

--- a/Sources/DVR/Dict+Extension.swift
+++ b/Sources/DVR/Dict+Extension.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Dictionary where Key == String {
+    subscript(caseInsensitive key: Key) -> Value? {
+        get {
+            if let k = keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }) {
+                return self[k]
+            }
+            return nil
+        }
+        set {
+            if let k = keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }) {
+                // remove the old key and set the new one
+                self[k] = nil
+                self[key] = newValue
+            } else {
+                self[key] = newValue
+            }
+        }
+    }
+}

--- a/Sources/DVR/Filter.swift
+++ b/Sources/DVR/Filter.swift
@@ -60,7 +60,7 @@ public struct Filter {
             return
         }
         for (key, filter) in filterHeaders ?? [:] {
-            guard let match = request.allHTTPHeaderFields![key] else {
+            guard let match = request.allHTTPHeaderFields![caseInsensitive: key] else {
                 continue
             }
             switch filter {
@@ -82,16 +82,16 @@ public struct Filter {
         }
         var headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.map { ($0 as! String, $1 as! String) })
         for (key, filter) in filterHeaders ?? [:] {
-            guard let match = headers[key] else {
+            guard let match = headers[caseInsensitive: key] else {
                 continue
             }
             switch filter {
             case .remove:
-                headers[key] = nil
+                headers[caseInsensitive: key] = nil
             case let .replace(replacement):
-                headers[key] = replacement
+                headers[caseInsensitive: key] = replacement
             case let .closure(function):
-                headers[key] = function(key, match)
+                headers[caseInsensitive: key] = function(key, match)
             }
         }
         response = Foundation.HTTPURLResponse(

--- a/Tests/DVRTests/FilterTests.swift
+++ b/Tests/DVRTests/FilterTests.swift
@@ -1,11 +1,3 @@
-//
-//  FilterTests.swift
-//  DVRTests-iOS
-//
-//  Created by Jáir Myree on 6/22/21.
-//  Copyright © 2021 Venmo. All rights reserved.
-//
-
 import XCTest
 import Foundation
 @testable import DVR
@@ -14,7 +6,7 @@ class FilterTests: XCTestCase {
 
     lazy var request: URLRequest = {
         var request = URLRequest(url: URL(string: "https://www.example.com?param1=val1&param2=val2&param3=val3")!)
-        request.allHTTPHeaderFields = ["header1": "stuff1", "header2": "stuff2", "header3": "stuff3"]
+        request.allHTTPHeaderFields = ["Header1": "stuff1", "Header2": "stuff2", "Header3": "stuff3"]
         return request
     }()
 
@@ -23,7 +15,7 @@ class FilterTests: XCTestCase {
             url: URL(string: "https://www.example/com")!,
             statusCode: 200,
             httpVersion: "",
-            headerFields: ["header1": "value1", "header2": "value2", "header3": "value3"]
+            headerFields: ["Header1": "value1", "Header2": "value2", "Header3": "value3"]
         )
         return response!
     }()


### PR DESCRIPTION
For example: `["authorization": .remove]` will remove both "authorization" an "Authorization" headers, regardless of casing.